### PR TITLE
Create method to transform vertext set.

### DIFF
--- a/src/main/scala/org/apache/mesos/chronos/scheduler/api/JobManagementResource.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/api/JobManagementResource.scala
@@ -324,11 +324,7 @@ class JobManagementResource @Inject()(val jobScheduler: JobScheduler,
   @Timed
   def getSummary(): Response = {
     try {
-      import scala.collection.JavaConversions._
-      val jobs = jobGraph.dag.vertexSet()
-        .flatMap {
-          jobGraph.getJobForName
-        }
+      val jobs = jobGraph.transformVertextSet(j => jobGraph.getJobForName(j))
         .map {
           job =>
             val state = Exporter.getLastState(job).toString
@@ -368,12 +364,7 @@ class JobManagementResource @Inject()(val jobScheduler: JobScheduler,
              @QueryParam("offset") offset: Integer
             ) = {
     try {
-      val jobs = ListBuffer[BaseJob]()
-      import scala.collection.JavaConversions._
-      jobGraph.dag.vertexSet().map({
-        job =>
-          jobs += jobGraph.getJobForName(job).get
-      })
+      val jobs = jobGraph.transformVertextSet(j => jobGraph.getJobForName(j))
 
       val _limit: Integer = limit match {
         case x: Integer =>

--- a/src/main/scala/org/apache/mesos/chronos/scheduler/graph/JobGraph.scala
+++ b/src/main/scala/org/apache/mesos/chronos/scheduler/graph/JobGraph.scala
@@ -12,6 +12,7 @@ import org.jgrapht.graph.DefaultEdge
 import scala.collection.convert.decorateAsScala._
 import scala.collection.mutable.ListBuffer
 import scala.collection.{mutable, _}
+import scala.collection.JavaConverters._
 
 /**
   * This class provides methods to access dependency structures of jobs.
@@ -51,6 +52,14 @@ class JobGraph {
     else
       Some(parents)
   }
+
+
+  def transformVertextSet[T](f: String => Option[T]): Set[T] = {
+    lock.synchronized {
+      dag.vertexSet().asScala.flatMap(vertex => f(vertex))
+    }
+  }
+
 
   def getJobForName(name: String): Option[BaseJob] = {
     jobNameMapping.get(name)


### PR DESCRIPTION
* The `vertexSet()` method returns a `UnModifiableCollection` which is only a wrapper around the original collection.
* This makes sure reads are not dirty.
